### PR TITLE
Added function to generate a string for animated QR codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ New(opts Options) (*bankID, error)
 
 // cancel current pending order
 (b *bankID) Cancel(ctx context.Context, opts CancelOptions) error
+
+// generate hashed string for animated qr code
+Qr(startToken, startSecret string, seconds int64) (string, error)
 ```
 
 ## Usage

--- a/bankid.go
+++ b/bankid.go
@@ -5,9 +5,12 @@ import (
 	"bytes"
 	"context"
 	"crypto"
+	"crypto/hmac"
+	"crypto/sha256"
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/base64"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"golang.org/x/crypto/pkcs12"
@@ -407,4 +410,15 @@ func (b *BankID) Cancel(ctx context.Context, opts CancelOptions) error {
 	}
 
 	return nil
+}
+
+// Qr is a helper function that generates a string that is transformed into a QR code. It takes startToken, startSecret
+// and seconds since the auth order was created.
+func Qr(startToken, startSecret string, seconds int64) (string, error) {
+	hash := hmac.New(sha256.New, []byte(fmt.Sprintf("%s, %d", startSecret, seconds)))
+	var authCode []byte
+	if _, err := hash.Write(authCode); err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("bankid.%s.%d.%s", startToken, seconds, hex.EncodeToString(authCode)), nil
 }

--- a/bankid.go
+++ b/bankid.go
@@ -413,7 +413,7 @@ func (b *BankID) Cancel(ctx context.Context, opts CancelOptions) error {
 }
 
 // Qr is a helper function that generates a string that is transformed into a QR code. It takes startToken, startSecret
-// and seconds since the auth order was created.
+// and seconds since the auth order was created. The QR Code need to be updated every second.
 func Qr(startToken, startSecret string, seconds int64) (string, error) {
 	hash := hmac.New(sha256.New, []byte(startSecret))
 	_, err := hash.Write([]byte(fmt.Sprintf("%d", seconds)))

--- a/bankid.go
+++ b/bankid.go
@@ -415,10 +415,10 @@ func (b *BankID) Cancel(ctx context.Context, opts CancelOptions) error {
 // Qr is a helper function that generates a string that is transformed into a QR code. It takes startToken, startSecret
 // and seconds since the auth order was created.
 func Qr(startToken, startSecret string, seconds int64) (string, error) {
-	hash := hmac.New(sha256.New, []byte(fmt.Sprintf("%s, %d", startSecret, seconds)))
-	var authCode []byte
-	if _, err := hash.Write(authCode); err != nil {
+	hash := hmac.New(sha256.New, []byte(startSecret))
+	_, err := hash.Write([]byte(fmt.Sprintf("%d", seconds)))
+	if err != nil {
 		return "", err
 	}
-	return fmt.Sprintf("bankid.%s.%d.%s", startToken, seconds, hex.EncodeToString(authCode)), nil
+	return fmt.Sprintf("bankid.%s.%d.%s", startToken, seconds, hex.EncodeToString(hash.Sum(nil))), nil
 }

--- a/bankid_test.go
+++ b/bankid_test.go
@@ -181,6 +181,7 @@ func TestBankId_Cancel(t *testing.T) {
 }
 
 func TestQr(t *testing.T) {
-	_, err := bankid.Qr("c15f3d1d-a209-4c64-89fe-c54209f55146", "43025f26-7cf3-415b-9c66-50835ee8deb4", 0)
+	str, err := bankid.Qr("c15f3d1d-a209-4c64-89fe-c54209f55146", "43025f26-7cf3-415b-9c66-50835ee8deb4", 0)
 	assert.NoError(t, err)
+	assert.NotEmpty(t, str)
 }

--- a/bankid_test.go
+++ b/bankid_test.go
@@ -179,3 +179,8 @@ func TestBankId_Cancel(t *testing.T) {
 
 	assert.Error(t, err)
 }
+
+func TestQr(t *testing.T) {
+	_, err := bankid.Qr("c15f3d1d-a209-4c64-89fe-c54209f55146", "43025f26-7cf3-415b-9c66-50835ee8deb4", 0)
+	assert.NoError(t, err)
+}


### PR DESCRIPTION
- Added the function signature `Qr(startToken, startSecret string, seconds int64) (string, error)`

When you want to use animated QR codes for increased security, you need to call this method and render a new QR code in the client once every second. `Qr` is a helper function.

The Qr method will generate a string that looks like this: `bankid.689f159c-e7c3-4611-a766-ba0cf27f6bf0.10.86d4c963c79e2e5ad5a55d05b7f415278e4e95b5ee30a6d3a5e60f8e7291fc29` according to the specification.
