### PR TITLE
Trim extra slashes from URL

### DIFF
--- a/bankid.go
+++ b/bankid.go
@@ -14,6 +14,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
 
 	pkcs12 "software.sslmate.com/src/go-pkcs12"
@@ -93,7 +94,7 @@ func New(opts Options) (*BankID, error) {
 
 	return &BankID{
 		client: client,
-		url:    opts.URL,
+		url:    strings.TrimSuffix(opts.URL, "/"),
 	}, nil
 }
 


### PR DESCRIPTION
Hello there,

I used this excellent library to implement BankID for my company, but had an issue that took me a while to figure out. On bankid.com, the production URL for the BankID API is written as "https://appapi2.bankid.com/" - i.e. it has a trailing slash. When this URL is used in the call to `bankid.New()` the bankid package will use double slashes resulting in API end point URLs like e.g. `https://appapi2.bankid.com//rp/v6.0/sign`. This would not (IMHO) be an issue to developer users like myself if only the BankID server had decent error handling, but it doesn't. Instead of giving a 404 or 400 response code it just hangs up, apparently. The error information I get out of the bankid package is "EOF". Not very illuminating and it took me a while to figure out what was wrong.

Because the URL at bankid.com is likely to be copy-pasted by people (not just me) and this issue is not super easy to debug I'd suggest the bankid package tries some basic sanitizing of the URL supplied. This patch trims any trailing slashes, which fixes this problem.